### PR TITLE
Update dependencies, docs, and improve CLI support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,15 +12,19 @@ repos:
     hooks:
       - id: yamlfmt
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.6
+    rev: v0.11.2
     hooks:
       - id: ruff
         args: [--fix]
       - id: ruff-format
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: v2.5.0
+    rev: v2.5.1
     hooks:
       - id: pyproject-fmt
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    rev: 0.6.9
+    hooks:
+      - id: uv-lock
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.15.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
     hooks:
       - id: mypy
         args: []
-        additional_dependencies: ["mcp>=1.5", "pytest>=8", "fastapi>=0.115"]
+        additional_dependencies: ["mcp>=1.5", "rich-click>=1.8.6", "pytest>=8", "fastapi>=0.115"]
   - repo: local
     hooks:
       - id: pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
     hooks:
       - id: mypy
         args: []
-        additional_dependencies: ["mcp==1.3.0", "pytest>=8.3.4", "fastapi>=0.115.8"]
+        additional_dependencies: ["mcp>=1.5", "pytest>=8", "fastapi>=0.115"]
   - repo: local
     hooks:
       - id: pytest

--- a/README.md
+++ b/README.md
@@ -14,30 +14,6 @@ A MCP server for interacting with [Bear](https://bear.app/) note-taking software
 
 ## Installation
 
-### For Claude Desktop
-To configure this server for Claude Desktop, edit the `claude_desktop_config.json` file with the following entry under
-`mcpServers`:
-
-```json
-{
-  "mcpServers": {
-    "youtube-transcript": {
-      "command": "uvx",
-      "args": [
-        "--from",
-        "git+https://github.com/jkawamoto/mcp-bear",
-        "mcp-bear",
-        "--token",
-        "<YOUR_TOKEN>"
-      ]
-    }
-  }
-}
-```
-After editing, restart the application.
-For more information,
-see: [For Claude Desktop Users - Model Context Protocol](https://modelcontextprotocol.io/quickstart/user).
-
 ### For Goose CLI
 To enable the Bear extension in Goose CLI,
 edit the configuration file `~/.config/goose/config.yaml` to include the following entry:
@@ -67,7 +43,31 @@ For more details on configuring MCP servers in Goose Desktop,
 refer to the documentation:
 [Using Extensions - MCP Servers](https://block.github.io/goose/docs/getting-started/using-extensions#mcp-servers).
 
-### Installing via Smithery
+### For Claude Desktop
+To configure this server for Claude Desktop, edit the `claude_desktop_config.json` file with the following entry under
+`mcpServers`:
+
+```json
+{
+  "mcpServers": {
+    "youtube-transcript": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/jkawamoto/mcp-bear",
+        "mcp-bear",
+        "--token",
+        "<YOUR_TOKEN>"
+      ]
+    }
+  }
+}
+```
+After editing, restart the application.
+For more information,
+see: [For Claude Desktop Users - Model Context Protocol](https://modelcontextprotocol.io/quickstart/user).
+
+#### Installing via Smithery
 To install Bear MCP Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@jkawamoto/mcp-bear):
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "hatchling" ]
 
 [project]
 name = "mcp-bear"
-version = "0.1.1"
+version = "0.1.2"
 description = "A MCP server for interacting with Bear note-taking software."
 readme = "README.md"
 authors = [
@@ -49,7 +49,7 @@ line-length = 120
 indent = 4
 
 [tool.bumpversion]
-current_version = "0.1.1"
+current_version = "0.1.2"
 commit = true
 pre_commit_hooks = [
     "uv sync",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,10 +24,10 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "click>=8.1.8",
     "fastapi>=0.115",
     "mcp>=1.5",
     "pydantic>=2.10.6",
+    "rich-click>=1.8.6",
     "uvicorn>=0.34",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ classifiers = [
 ]
 dependencies = [
     "click>=8.1.8",
-    "fastapi>=0.115.8",
-    "mcp>=1.3",
+    "fastapi>=0.115",
+    "mcp>=1.5",
     "pydantic>=2.10.6",
     "uvicorn>=0.34",
 ]
@@ -35,10 +35,10 @@ scripts.mcp-bear = "mcp_bear:main"
 
 [dependency-groups]
 dev = [
-    "bump-my-version>=0.32.2",
-    "pre-commit>=4.1",
-    "pre-commit-uv>=4.1.4",
-    "pytest>=8.3.4",
+    "bump-my-version>=1",
+    "pre-commit>=4",
+    "pre-commit-uv>=4",
+    "pytest>=8",
 ]
 
 [tool.ruff]

--- a/src/mcp_bear/__init__.py
+++ b/src/mcp_bear/__init__.py
@@ -10,7 +10,7 @@ import socket
 import sys
 from typing import Final
 
-import click
+import rich_click as click
 
 from mcp_bear.server import create_server
 

--- a/src/mcp_bear/server.py
+++ b/src/mcp_bear/server.py
@@ -20,6 +20,7 @@ from urllib.parse import urlencode, quote, unquote_plus
 from fastapi import FastAPI, Request
 from mcp.server import FastMCP
 from mcp.server.fastmcp import Context
+from mcp.server.session import ServerSessionT
 from pydantic import Field
 from starlette.datastructures import QueryParams
 from uvicorn import Config, Server
@@ -119,12 +120,12 @@ def create_server(token: str, callback_host: str, callback_port: int) -> FastMCP
 
     @mcp.tool()
     async def open_note(
-        ctx: Context,
+        ctx: Context[ServerSessionT, AppContext],
         id: str | None = Field(description="note unique identifier", default=None),
         title: str | None = Field(description="note title", default=None),
     ) -> str:
         """Open a note identified by its title or id and return its content."""
-        app_ctx: AppContext = ctx.request_context.lifespan_context
+        app_ctx = ctx.request_context.lifespan_context
         future = Future[QueryParams]()
         await app_ctx.open_note_results.put(future)
 
@@ -151,14 +152,14 @@ def create_server(token: str, callback_host: str, callback_port: int) -> FastMCP
 
     @mcp.tool()
     async def create(
-        ctx: Context,
+        ctx: Context[ServerSessionT, AppContext],
         title: str | None = Field(description="note title", default=None),
         text: str | None = Field(description="note body", default=None),
         tags: list[str] | None = Field(description="list of tags", default=None),
         timestamp: bool = Field(description="prepend the current date and time to the text", default=False),
     ) -> str:
         """Create a new note and return its unique identifier. Empty notes are not allowed."""
-        app_ctx: AppContext = ctx.request_context.lifespan_context
+        app_ctx = ctx.request_context.lifespan_context
         future = Future[QueryParams]()
         await app_ctx.create_results.put(future)
 
@@ -186,10 +187,10 @@ def create_server(token: str, callback_host: str, callback_port: int) -> FastMCP
 
     @mcp.tool()
     async def tags(
-        ctx: Context,
+        ctx: Context[ServerSessionT, AppContext],
     ) -> list[str]:
         """Return all the tags currently displayed in Bear’s sidebar."""
-        app_ctx: AppContext = ctx.request_context.lifespan_context
+        app_ctx = ctx.request_context.lifespan_context
         future = Future[QueryParams]()
         await app_ctx.tags_results.put(future)
 
@@ -207,11 +208,11 @@ def create_server(token: str, callback_host: str, callback_port: int) -> FastMCP
 
     @mcp.tool()
     async def open_tag(
-        ctx: Context,
+        ctx: Context[ServerSessionT, AppContext],
         name: str = Field(description="tag name or a list of tags divided by comma"),
     ) -> list[str]:
         """Show all the notes which have a selected tag in bear."""
-        app_ctx: AppContext = ctx.request_context.lifespan_context
+        app_ctx = ctx.request_context.lifespan_context
         future = Future[QueryParams]()
         await app_ctx.open_tag_results.put(future)
 
@@ -230,11 +231,11 @@ def create_server(token: str, callback_host: str, callback_port: int) -> FastMCP
 
     @mcp.tool()
     async def todo(
-        ctx: Context,
+        ctx: Context[ServerSessionT, AppContext],
         search: str | None = Field(description="string to search", default=None),
     ) -> list[str]:
         """Select the Todo sidebar item."""
-        app_ctx: AppContext = ctx.request_context.lifespan_context
+        app_ctx = ctx.request_context.lifespan_context
         future = Future[QueryParams]()
         await app_ctx.todo_results.put(future)
 
@@ -255,11 +256,11 @@ def create_server(token: str, callback_host: str, callback_port: int) -> FastMCP
 
     @mcp.tool()
     async def today(
-        ctx: Context,
+        ctx: Context[ServerSessionT, AppContext],
         search: str | None = Field(description="string to search", default=None),
     ) -> list[str]:
         """Select the Today sidebar item."""
-        app_ctx: AppContext = ctx.request_context.lifespan_context
+        app_ctx = ctx.request_context.lifespan_context
         future = Future[QueryParams]()
         await app_ctx.today_results.put(future)
 
@@ -280,12 +281,12 @@ def create_server(token: str, callback_host: str, callback_port: int) -> FastMCP
 
     @mcp.tool()
     async def search(
-        ctx: Context,
+        ctx: Context[ServerSessionT, AppContext],
         term: str | None = Field(description="string to search", default=None),
         tag: str | None = Field(description="tag to search into", default=None),
     ) -> list[str]:
         """Show search results in Bear for all notes or for a specific tag."""
-        app_ctx: AppContext = ctx.request_context.lifespan_context
+        app_ctx = ctx.request_context.lifespan_context
         future = Future[QueryParams]()
         await app_ctx.search_results.put(future)
 
@@ -308,7 +309,7 @@ def create_server(token: str, callback_host: str, callback_port: int) -> FastMCP
 
     @mcp.tool()
     async def grab_url(
-        ctx: Context,
+        ctx: Context[ServerSessionT, AppContext],
         url: str = Field(description="url to grab"),
         tags: list[str] | None = Field(
             description="list of tags. If tags are specified in the Bear’s web content preferences, this parameter is ignored.",
@@ -316,7 +317,7 @@ def create_server(token: str, callback_host: str, callback_port: int) -> FastMCP
         ),
     ) -> str:
         """Create a new note with the content of a web page and return its unique identifier."""
-        app_ctx: AppContext = ctx.request_context.lifespan_context
+        app_ctx = ctx.request_context.lifespan_context
         future = Future[QueryParams]()
         await app_ctx.grab_url_results.put(future)
 

--- a/uv.lock
+++ b/uv.lock
@@ -243,10 +243,10 @@ name = "mcp-bear"
 version = "0.1.1"
 source = { editable = "." }
 dependencies = [
-    { name = "click" },
     { name = "fastapi" },
     { name = "mcp" },
     { name = "pydantic" },
+    { name = "rich-click" },
     { name = "uvicorn" },
 ]
 
@@ -260,10 +260,10 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "click", specifier = ">=8.1.8" },
     { name = "fastapi", specifier = ">=0.115" },
     { name = "mcp", specifier = ">=1.5" },
     { name = "pydantic", specifier = ">=2.10.6" },
+    { name = "rich-click", specifier = ">=1.8.6" },
     { name = "uvicorn", specifier = ">=0.34" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -240,7 +240,7 @@ wheels = [
 
 [[package]]
 name = "mcp-bear"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/uv.lock
+++ b/uv.lock
@@ -36,7 +36,7 @@ wheels = [
 
 [[package]]
 name = "bump-my-version"
-version = "0.32.2"
+version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -49,9 +49,9 @@ dependencies = [
     { name = "tomlkit" },
     { name = "wcmatch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/4c/535904dd2575b40ba672e333808521a8f93a8e30c5fb0bfb9051813fa17e/bump_my_version-0.32.2.tar.gz", hash = "sha256:fc1c686af66c39c44d2f19c4d29597fcc2f938bc19046b8df26bfa44c93f11c0", size = 1068097 }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/0a/b4e0dea19ca92d871b011dfbd4271d2ea627db74a6b651ea642a7c605cf7/bump_my_version-1.1.1.tar.gz", hash = "sha256:2f590e0eabe894196289c296c52170559c09876454514ae8fce5db75bd47289e", size = 1108000 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/4b/1bc70caa460d41243d30ba02b96ee8e726da679e541231ccc9cff86051bb/bump_my_version-0.32.2-py3-none-any.whl", hash = "sha256:fb93c5a70a2368354bcac4457d22f282dc66a7bd241241f5a4e3d49002dece36", size = 57614 },
+    { url = "https://files.pythonhosted.org/packages/b0/a7/c516c75f624b4dc7afde397af3bf5c01c6b191e18bcccfa44ec0d7d4a4e4/bump_my_version-1.1.1-py3-none-any.whl", hash = "sha256:6bd78e20421f6335c1a49d7e85a2f16ae8966897d0a2dd130a0e8b6b55954686", size = 59474 },
 ]
 
 [[package]]
@@ -113,16 +113,16 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.115.8"
+version = "0.115.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "starlette" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/b2/5a5dc4affdb6661dea100324e19a7721d5dc524b464fe8e366c093fd7d87/fastapi-0.115.8.tar.gz", hash = "sha256:0ce9111231720190473e222cdf0f07f7206ad7e53ea02beb1d2dc36e2f0741e9", size = 295403 }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/28/c5d26e5860df807241909a961a37d45e10533acef95fc368066c7dd186cd/fastapi-0.115.11.tar.gz", hash = "sha256:cc81f03f688678b92600a65a5e618b93592c65005db37157147204d8924bf94f", size = 294441 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/7d/2d6ce181d7a5f51dedb8c06206cbf0ec026a99bf145edd309f9e17c3282f/fastapi-0.115.8-py3-none-any.whl", hash = "sha256:753a96dd7e036b34eeef8babdfcfe3f28ff79648f86551eb36bfc1b0bf4a8cbf", size = 94814 },
+    { url = "https://files.pythonhosted.org/packages/b3/5d/4d8bbb94f0dbc22732350c06965e40740f4a92ca560e90bb566f4f73af41/fastapi-0.115.11-py3-none-any.whl", hash = "sha256:32e1541b7b74602e4ef4a0260ecaf3aadf9d4f19590bba3e1bf2ac4666aa2c64", size = 94926 },
 ]
 
 [[package]]
@@ -221,7 +221,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.3.0"
+version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -233,9 +233,9 @@ dependencies = [
     { name = "starlette" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/b6/81e5f2490290351fc97bf46c24ff935128cb7d34d68e3987b522f26f7ada/mcp-1.3.0.tar.gz", hash = "sha256:f409ae4482ce9d53e7ac03f3f7808bcab735bdfc0fba937453782efb43882d45", size = 150235 }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/c9/c55764824e893fdebe777ac7223200986a275c3191dba9169f8eb6d7c978/mcp-1.5.0.tar.gz", hash = "sha256:5b2766c05e68e01a2034875e250139839498c61792163a7b221fc170c12f5aa9", size = 159128 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/d2/a9e87b506b2094f5aa9becc1af5178842701b27217fa43877353da2577e3/mcp-1.3.0-py3-none-any.whl", hash = "sha256:2829d67ce339a249f803f22eba5e90385eafcac45c94b00cab6cef7e8f217211", size = 70672 },
+    { url = "https://files.pythonhosted.org/packages/c1/d1/3ff566ecf322077d861f1a68a1ff025cad337417bd66ad22a7c6f7dfcfaf/mcp-1.5.0-py3-none-any.whl", hash = "sha256:51c3f35ce93cb702f7513c12406bbea9665ef75a08db909200b07da9db641527", size = 73734 },
 ]
 
 [[package]]
@@ -261,18 +261,18 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.1.8" },
-    { name = "fastapi", specifier = ">=0.115.8" },
-    { name = "mcp", specifier = ">=1.3" },
+    { name = "fastapi", specifier = ">=0.115" },
+    { name = "mcp", specifier = ">=1.5" },
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "uvicorn", specifier = ">=0.34" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "bump-my-version", specifier = ">=0.32.2" },
-    { name = "pre-commit", specifier = ">=4.1" },
-    { name = "pre-commit-uv", specifier = ">=4.1.4" },
-    { name = "pytest", specifier = ">=8.3.4" },
+    { name = "bump-my-version", specifier = ">=1" },
+    { name = "pre-commit", specifier = ">=4" },
+    { name = "pre-commit-uv", specifier = ">=4" },
+    { name = "pytest", specifier = ">=8" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

This pull request introduces the following changes:

- **Version bump**: Incremented project version from `0.1.1` to `0.1.2`.
- **Improved CLI support**: Replaced `click` with `rich-click` for a more feature-rich CLI experience. Dependencies and imports were updated accordingly.
- **README enhancements**: Reorganized sections for better clarity, ensuring Smithery installation is properly nested under Claude Desktop.
- **Type error fixes**: Updated `Context` type annotations for improved consistency. Simplified redundant type hints.
- **Dependency updates**: Upgraded production and development dependencies (`fastapi`, `mcp`, `pytest`, etc.) for improved compatibility and robustness.
- **Pre-commit updates**: Enhanced tooling by updating hooks (ruff, pyproject-fmt) and adding the `uv-lock` hook for dependency locking.

