### PR TITLE
Add a replace_note method using the add-text endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Refer to Bear's [X-callback-url Scheme documentation](https://bear.app/faq/x-cal
 
 - [x] /open-note
 - [x] /create
-- [ ] /add-text
+- [x] /add-text (partially, via the replace_note method)
 - [ ] /add-file
 - [x] /tags
 - [x] /open-tag

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -40,3 +40,4 @@ async def test_list_tools(mcp_client_session: ClientSession) -> None:
     assert "today" in tools
     assert "search" in tools
     assert "grab_url" in tools
+    assert "replace_note" in tools


### PR DESCRIPTION
(@jkawamoto feel free to ignore if you're not taking contributions - I found this valuable for my own usage and figured I'd put it up)

Adds a new `replace_note` method that allows replacing the content of existing Bear notes.

Uses Bear's `/add-text` endpoint with:
- `mode=replace` - preserves existing note title
- `mode=replace_all` - replaces title and content (when `title` provided)