### PR TITLE
Increase max header size to 1MB

### DIFF
--- a/src/mcp_bear/__init__.py
+++ b/src/mcp_bear/__init__.py
@@ -95,6 +95,7 @@ async def app_lifespan(_server: FastMCP, uds: Path) -> AsyncIterator[AppContext]
             uds=str(uds),
             log_level="warning",
             log_config=log_config,
+            h11_max_incomplete_event_size=1024 * 1024,  # 1MB
         )
     )
 


### PR DESCRIPTION
This pull request addresses the issue where Uvicorn was rejecting HTTP requests with headers exceeding 16KB. The maximum header size has been increased to 1MB to accommodate larger headers, resolving compatibility issues with requests containing extensive data.

See also #17.