### PR TITLE
fix: prevent title from being duplicated in the note

### DIFF
--- a/src/mcp_bear/__init__.py
+++ b/src/mcp_bear/__init__.py
@@ -178,6 +178,9 @@ def server(token: str, uds: Path) -> FastMCP:
         if title is not None:
             params["title"] = title
         if text is not None:
+            if title:
+                # remove the title from the note text to avoid being duplicated
+                text = text.removeprefix(title)
             params["text"] = text
         if tags is not None:
             params["tags"] = ",".join(tags)

--- a/src/mcp_bear/__init__.py
+++ b/src/mcp_bear/__init__.py
@@ -180,7 +180,7 @@ def server(token: str, uds: Path) -> FastMCP:
         if text is not None:
             if title:
                 # remove the title from the note text to avoid being duplicated
-                text = text.removeprefix(title)
+                text = text.removeprefix("# " + title)
             params["text"] = text
         if tags is not None:
             params["tags"] = ",".join(tags)


### PR DESCRIPTION
Hey! First of all, great work with this! I was so amazed when it worked flawlessly.
I noticed that the title was showing up twice on the note created with this MCP server.
This change should fix it. WDYT?

## Example

I asked it to create a note summarizing the Nintendo Switch 2 features and it made this request:
```json
{
  `tags`: `[\"gaming\", \"nintendo\", \"switch2\", \"console\"]`,
  `text`: `# Nintendo Switch 2 Features Summary
...
`,
  `title`: `Nintendo Switch 2 Features Summary`
}
```