### PR TITLE
Fix: Remove hardcoded pin=no parameter in open_note function

### DIFF
--- a/src/mcp_bear/__init__.py
+++ b/src/mcp_bear/__init__.py
@@ -110,7 +110,7 @@ def server(token: str, uds: Path) -> FastMCP:
             "show_window": "no",
             "open_note": "no",
             "selected": "no",
-            "pin": "no",
+            # Removed "pin": "no" to preserve existing pin status
             "edit": "no",
             "x-success": f"xfwder://{uds.stem}/{req_id}/success",
             "x-error": f"xfwder://{uds.stem}/{req_id}/error",


### PR DESCRIPTION
The open_note function was hardcoding 'pin': 'no' which caused pinned notes to become unpinned when reading their content. This should be a read-only operation that preserves the note's existing pin status.

Fixes issue where pinned notes lose their pin status after being accessed via MCP.