### PR TITLE
Fixed typo in Claude Desktop configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To configure this server for Claude Desktop, edit the `claude_desktop_config.jso
 ```json
 {
   "mcpServers": {
-    "youtube-transcript": {
+    "bear": {
       "command": "uvx",
       "args": [
         "--from",


### PR DESCRIPTION
There is a typo/copy-paste error in the readme config calling the server youtube-transcripts. This fix changes it to be called bear instead.